### PR TITLE
Update draft-turner-ccmib.md

### DIFF
--- a/draft-turner-ccmib.md
+++ b/draft-turner-ccmib.md
@@ -5494,7 +5494,7 @@ This module makes reference to: {{cc-fh}}, {{RFC2578}}, {{RFC2579}}, {{RFC2580}}
             "This object indicates what action the ECU should take on
             matching a data traffic flow against a filter (as defined by
             cSecPolicyRuleFilterReference). The value of this column can
-            take one of four enumeration values.
+            take one of five enumeration values.
 
             [1] protect: The 'protect' enumeration value indicates that
             the data traffic flow should be protected by a Secure


### PR DESCRIPTION
Per feedback received (A. Farrel - 11/19/2019): in-accurate description text for cSecPolicyRuleAction.  Changed description from "take one of four enumeration values" to "take one of five enumeration values".