### PR TITLE
Update draft-turner-ccmib.md

### DIFF
--- a/draft-turner-ccmib.md
+++ b/draft-turner-ccmib.md
@@ -67,10 +67,6 @@ operators of these and any other system deployments.
 Introduction
 ============
 
-RFC EDITOR: PLEASE REMOVE THE FOLLOWING PARAGRAPH PRIOR TO PUBLICATION
-
-The source for this draft is maintained in GitHub. Suggested changes should be submitted as pull requests at https://github.com/seanturner/draft-turner-ccmib. Instructions are on that page as well. Editorial changes can be managed in GitHub. 
-
 This document defines a portion of the Management Information Base (MIB) for use with network management protocols in the Internet community.  In particular, it describes managed objects used to manage key management implementations including asymmetric keys, symmetric keys, trust anchors, and cryptographic-related firmware.
 
 This profile applies to the capabilities, configuration, and operation


### PR DESCRIPTION
Per comments received feedback received (A. Farrel - 11/19/2019): suggestion was to go ahead and remove the GitHub paragraph.  This was implemented as such.