### PR TITLE
Update draft-turner-ccmib.md

### DIFF
--- a/draft-turner-ccmib.md
+++ b/draft-turner-ccmib.md
@@ -620,8 +620,7 @@ This MIB module makes reference to the following documents: {{?RFC1213}}, {{RFC2
     cDeviceComponentDisabled  NOTIFICATION-TYPE
         OBJECTS     {
                         cDeviceComponentName,
-                        cDeviceComponentVersion,
-                        cDeviceComponentOpStatus
+                        cDeviceComponentVersion
                     }
         STATUS      current
         DESCRIPTION


### PR DESCRIPTION
Per comments received feedback received (A. Farrel - 11/19/2019): having the notification include cDeviceComponentOpStatus was redundant since the the notification implies the component is inherently disabled (cDeviceComponentDisabled).