### PR TITLE
Update draft-turner-ccmib.md

### DIFF
--- a/draft-turner-ccmib.md
+++ b/draft-turner-ccmib.md
@@ -849,12 +849,14 @@ This MIB module makes reference to the following documents: {{?RFC1213}}, {{RFC2
 
     cBatteryOpStatus  OBJECT-TYPE
         SYNTAX      INTEGER { unknown(1), batteryNormal(2),
-                              batteryLow(3), batteryDepleted(4),
+                              batteryLow(3), batteryEmpty(4),
                               batteryMissing(5) }
         MAX-ACCESS  read-only
         STATUS      current
         DESCRIPTION 
-            "Indication of the status of the battery."
+            "Indication of the status of the battery.  Note, the 
+            batteryLow(3) state is determined by the 
+            cBatteryLowThreshold value."
         ::= { cBatteryInfoEntry 3 }
 
     cBatteryLowThreshold  OBJECT-TYPE


### PR DESCRIPTION
Per comments received feedback received (A. Farrel - 11/19/2019): "batteryDepleted" was changed to "batteryEmpty".  Also added wording to associate cBatteryOpStatus - batteryLow(3) enumeration with cBatteryLowThreshold.