### PR TITLE
Update draft-turner-ccmib.md

### DIFF
--- a/draft-turner-ccmib.md
+++ b/draft-turner-ccmib.md
@@ -347,7 +347,7 @@ This MIB module makes reference to the following documents: {{?RFC1213}}, {{RFC2
             FROM SNMPv2-SMI                            -- FROM RFC 2578
         SnmpAdminString
             FROM SNMP-FRAMEWORK-MIB                    -- FROM RFC 3411
-        DateAndTime, TruthValue, TimeStamp, RowStatus
+        DateAndTime, TruthValue, RowStatus
             FROM SNMPv2-TC;                            -- FROM RFC 2579
 
     ccDeviceInfoMIB  MODULE-IDENTITY
@@ -672,7 +672,7 @@ This MIB module makes reference to the following documents: {{?RFC1213}}, {{RFC2
         ::= { cDeviceComponentVersInfo 1 }
 
     cDeviceComponentVersTableLastChanged  OBJECT-TYPE
-        SYNTAX      TimeStamp
+        SYNTAX      TimeTicks
         MAX-ACCESS  read-only
         STATUS      current
         DESCRIPTION
@@ -801,7 +801,7 @@ This MIB module makes reference to the following documents: {{?RFC1213}}, {{RFC2
         ::= { cBatteryInfo 1 }
 
     cBatteryInfoTableLastChanged  OBJECT-TYPE
-        SYNTAX      TimeStamp
+        SYNTAX      TimeTicks
         MAX-ACCESS  read-only
         STATUS      current
         DESCRIPTION 
@@ -913,7 +913,7 @@ This MIB module makes reference to the following documents: {{?RFC1213}}, {{RFC2
         ::= { cFirmwareInfo 1 }
 
     cFirmwareInformationTableLastChanged  OBJECT-TYPE
-        SYNTAX      TimeStamp
+        SYNTAX      TimeTicks
         MAX-ACCESS  read-only
         STATUS      current
         DESCRIPTION 
@@ -1238,12 +1238,12 @@ This MIB module makes references to the following documents: {{RFC2578}}, {{RFC2
         ccKeyManagement
             FROM CC-FEATURE-HIERARCHY-MIB              -- FROM Sec 6.2
         OBJECT-TYPE, Unsigned32, NOTIFICATION-TYPE,
-        MODULE-IDENTITY
+        MODULE-IDENTITY, TimeTicks
             FROM SNMPv2-SMI                            -- FROM RFC 2578
         SnmpAdminString
             FROM SNMP-FRAMEWORK-MIB                    -- FROM RFC 3411
         RowPointer, RowStatus, DateAndTime,
-        TruthValue, TimeStamp
+        TruthValue
             FROM SNMPv2-TC                             -- FROM RFC 2579
         MODULE-COMPLIANCE, OBJECT-GROUP,
         NOTIFICATION-GROUP
@@ -1667,7 +1667,7 @@ This MIB module makes references to the following documents: {{RFC2578}}, {{RFC2
         ::= { cSymmetricKeyInfo 1 }
 
     cSymmetricKeyTableLastChanged  OBJECT-TYPE
-        SYNTAX      TimeStamp
+        SYNTAX      TimeTicks
         MAX-ACCESS  read-only
         STATUS      current
         DESCRIPTION
@@ -1937,7 +1937,7 @@ This MIB module makes references to the following documents: {{RFC2578}}, {{RFC2
         ::= { cAsymKeyInfo 1 }
 
     cAsymKeyTableLastChanged  OBJECT-TYPE
-        SYNTAX      TimeStamp
+        SYNTAX      TimeTicks
         MAX-ACCESS  read-only
         STATUS      current
         DESCRIPTION
@@ -2312,7 +2312,7 @@ This MIB module makes references to the following documents: {{RFC2578}}, {{RFC2
         ::= { cTrustAnchorInfo 1 }
 
     cTrustAnchorTableLastChanged  OBJECT-TYPE
-        SYNTAX      TimeStamp
+        SYNTAX      TimeTicks
         MAX-ACCESS  read-only
         STATUS      current
         DESCRIPTION
@@ -2479,7 +2479,7 @@ This MIB module makes references to the following documents: {{RFC2578}}, {{RFC2
         ::= { cCKLInfo 1 }
 
     cCKLLastChanged  OBJECT-TYPE
-        SYNTAX      TimeStamp
+        SYNTAX      TimeTicks
         MAX-ACCESS  read-only
         STATUS      current
         DESCRIPTION
@@ -2634,7 +2634,7 @@ This MIB module makes references to the following documents: {{RFC2578}}, {{RFC2
         ::= { cCDMStoreInfo 1 }
 
     cCDMStoreTableLastChanged  OBJECT-TYPE
-        SYNTAX      TimeStamp
+        SYNTAX      TimeTicks
         MAX-ACCESS  read-only
         STATUS      current
         DESCRIPTION
@@ -2804,7 +2804,7 @@ This MIB module makes references to the following documents: {{RFC2578}}, {{RFC2
         ::= { cCertSubAltNameInfo 1 }
     
     cCertSubAltNameTableLastChanged OBJECT-TYPE
-        SYNTAX      TimeStamp
+        SYNTAX      TimeTicks
         MAX-ACCESS  read-only
         STATUS      current
         DESCRIPTION
@@ -2949,7 +2949,7 @@ This MIB module makes references to the following documents: {{RFC2578}}, {{RFC2
         ::= { cCertPathCtrlsInfo 1 }
 
     cCertPathCtrlsTableLastChanged OBJECT-TYPE
-        SYNTAX      TimeStamp
+        SYNTAX      TimeTicks
         MAX-ACCESS  read-only
         STATUS      current
         DESCRIPTION
@@ -3124,7 +3124,7 @@ This MIB module makes references to the following documents: {{RFC2578}}, {{RFC2
         ::= { cCertPolicyInfo 1 }
 
     cCertPolicyTableLastChanged OBJECT-TYPE
-        SYNTAX      TimeStamp
+        SYNTAX      TimeTicks
         MAX-ACCESS  read-only
         STATUS      current
         DESCRIPTION
@@ -3230,7 +3230,7 @@ This MIB module makes references to the following documents: {{RFC2578}}, {{RFC2
         ::= { cPolicyMappingInfo 1 }
 
     cPolicyMappingTableLastChanged OBJECT-TYPE
-        SYNTAX      TimeStamp
+        SYNTAX      TimeTicks
         MAX-ACCESS  read-only
         STATUS      current
         DESCRIPTION
@@ -3324,7 +3324,7 @@ This MIB module makes references to the following documents: {{RFC2578}}, {{RFC2
         ::= { cNameConstraintInfo 1 }
 
     cNameConstraintTableLastChanged OBJECT-TYPE
-        SYNTAX      TimeStamp
+        SYNTAX      TimeTicks
         MAX-ACCESS  read-only
         STATUS      current
         DESCRIPTION
@@ -3405,7 +3405,7 @@ This MIB module makes references to the following documents: {{RFC2578}}, {{RFC2
         ::= { cRemoteKeyMaterialInfo 1 }
 
     cRemoteKeyMaterialTableLastChanged OBJECT-TYPE
-        SYNTAX       TimeStamp
+        SYNTAX       TimeTicks
         MAX-ACCESS   read-only
         STATUS       current
         DESCRIPTION
@@ -4004,11 +4004,11 @@ This MIB module makes reference to the following documents: {{RFC2578}}, {{RFC25
         NOTIFICATION-GROUP
             FROM SNMPv2-CONF                           -- FROM RFC 2580
         OBJECT-TYPE, Unsigned32, NOTIFICATION-TYPE,
-        MODULE-IDENTITY
+        MODULE-IDENTITY, TimeTicks
             FROM SNMPv2-SMI                            -- FROM RFC 2578
         SnmpAdminString
             FROM SNMP-FRAMEWORK-MIB                    -- FROM RFC 3411
-        RowStatus, TimeStamp
+        RowStatus
             FROM SNMPv2-TC;                            -- FROM RFC 2579
 
     ccKeyTransferPullMIB  MODULE-IDENTITY
@@ -4258,7 +4258,7 @@ This MIB module makes reference to the following documents: {{RFC2578}}, {{RFC25
         ::= { cCDMServerInfo 1 }
 
     cCDMServerTableLastChanged  OBJECT-TYPE
-        SYNTAX      TimeStamp
+        SYNTAX      TimeTicks
         MAX-ACCESS  read-only
         STATUS      current
         DESCRIPTION
@@ -4372,7 +4372,7 @@ This MIB module makes reference to the following documents: {{RFC2578}}, {{RFC25
         ::= { cCDMDeliveryInfo 1 }
 
     cCDMDeliveryTableLastChanged  OBJECT-TYPE
-        SYNTAX      TimeStamp
+        SYNTAX      TimeTicks
         MAX-ACCESS  read-only
         STATUS      current
         DESCRIPTION
@@ -4737,12 +4737,11 @@ This MIB module makes reference to following documents: {{RFC2578}}, {{RFC2579}}
         ccKeyTransferPush
             FROM CC-FEATURE-HIERARCHY-MIB              -- FROM Sec 6.2
         OBJECT-TYPE, Unsigned32, NOTIFICATION-TYPE,
-        MODULE-IDENTITY
+        MODULE-IDENTITY, TimeTicks
             FROM SNMPv2-SMI                            -- FROM RFC 2578
         SnmpAdminString
             FROM SNMP-FRAMEWORK-MIB                    -- FROM RFC 3411
-        RowPointer, RowStatus, DateAndTime,
-        TimeStamp
+        RowPointer, RowStatus, DateAndTime     
             FROM SNMPv2-TC                             -- FROM RFC 2579
         MODULE-COMPLIANCE, OBJECT-GROUP,
         NOTIFICATION-GROUP
@@ -4886,7 +4885,7 @@ This MIB module makes reference to following documents: {{RFC2578}}, {{RFC2579}}
         ::= { cCDMPushDestInfo 1 }
 
     cCDMPushDestTableLastChanged  OBJECT-TYPE
-        SYNTAX      TimeStamp
+        SYNTAX      TimeTicks
         MAX-ACCESS  read-only
         STATUS      current
         DESCRIPTION
@@ -5026,7 +5025,7 @@ This MIB module makes reference to following documents: {{RFC2578}}, {{RFC2579}}
         ::= { cCDMTransferPkgInfo 1 }
     
     cCDMTransferPkgTableLastChanged  OBJECT-TYPE
-        SYNTAX      TimeStamp
+        SYNTAX      TimeTicks
         MAX-ACCESS  read-only
         STATUS      current
         DESCRIPTION
@@ -5129,7 +5128,7 @@ This MIB module makes reference to following documents: {{RFC2578}}, {{RFC2579}}
         ::= { cCDMPushSrcInfo 1 }
 
     cCDMPushSrcTableLastChanged  OBJECT-TYPE
-        SYNTAX      TimeStamp
+        SYNTAX      TimeTicks
         MAX-ACCESS  read-only
         STATUS      current
         DESCRIPTION
@@ -5354,14 +5353,14 @@ This module makes reference to: {{cc-fh}}, {{RFC2578}}, {{RFC2579}}, {{RFC2580}}
         ccSecurePolicyInfo
             FROM CC-FEATURE-HIERARCHY-MIB              -- FROM Sec 6.2
         OBJECT-TYPE, Unsigned32, NOTIFICATION-TYPE,
-        MODULE-IDENTITY
+        MODULE-IDENTITY, TimeTicks
             FROM SNMPv2-SMI                            -- FROM RFC 2578
         MODULE-COMPLIANCE, OBJECT-GROUP,
         NOTIFICATION-GROUP
             FROM SNMPv2-CONF                           -- FROM RFC 2580
         SnmpAdminString
             FROM SNMP-FRAMEWORK-MIB                    -- FROM RFC 3411
-        RowStatus, TimeStamp
+        RowStatus
             FROM SNMPv2-TC;                            -- FROM RFC 2579
 
     ccSecurePolicyInfoMIB  MODULE-IDENTITY
@@ -5437,7 +5436,7 @@ This module makes reference to: {{cc-fh}}, {{RFC2578}}, {{RFC2579}}, {{RFC2580}}
         ::= { cSecPolicyRuleInfo 1 }
 
     cSecPolicyRuleTableLastChanged  OBJECT-TYPE
-        SYNTAX      TimeStamp
+        SYNTAX      TimeTicks
         MAX-ACCESS  read-only
         STATUS      current
         DESCRIPTION
@@ -5652,12 +5651,12 @@ This module makes reference to: {{cc-fh}}, {{RFC2578}}, {{RFC2579}}, {{RFC2580}}
         ccSecureConnectionInfo
             FROM CC-FEATURE-HIERARCHY-MIB             -- FROM Sec 6.2
         OBJECT-TYPE, Unsigned32, NOTIFICATION-TYPE,
-        MODULE-IDENTITY
+        MODULE-IDENTITY, TimeTicks
             FROM SNMPv2-SMI                           -- FROM RFC 2578
         MODULE-COMPLIANCE, OBJECT-GROUP,
         NOTIFICATION-GROUP
             FROM SNMPv2-CONF                          -- FROM RFC 2580
-        RowStatus, DateAndTime, TimeStamp
+        RowStatus, DateAndTime
             FROM SNMPv2-TC;                           -- FROM RFC 2579
 
     ccSecureConnectionInfoMIB  MODULE-IDENTITY
@@ -5739,7 +5738,7 @@ This module makes reference to: {{cc-fh}}, {{RFC2578}}, {{RFC2579}}, {{RFC2580}}
         ::= { cSecureConnectionInfo 1 }
 
     cSecConTableLastChanged  OBJECT-TYPE
-        SYNTAX      TimeStamp
+        SYNTAX      TimeTicks
         MAX-ACCESS  read-only
         STATUS      current
         DESCRIPTION


### PR DESCRIPTION
Based on feedback received from A. Farrel (11/19/2019), changed the table *LastChanged - from TimeStamp to TimeTicks, since these objects are referencing cSystemUpTime.